### PR TITLE
Ubuntu18.04用のomniORB/omniORBpy4.2.3のdebパッケージ作成スクリプトを登録

### DIFF
--- a/ubuntu_1804/Dockerfile
+++ b/ubuntu_1804/Dockerfile
@@ -104,9 +104,9 @@ RUN python3 setup.py build \
  && python3 setup.py sdist
 
 WORKDIR /root/OpenRTM-aist-Python/dist
-RUN tar xf OpenRTM-aist-Python-1.2.1.tar.gz
-
-WORKDIR OpenRTM-aist-Python-1.2.1/packages
-RUN make \ 
+RUN VERSION=`python3 ../setup.py --version` \
+ && tar xf OpenRTM-aist-Python-${VERSION}.tar.gz \
+ && cd OpenRTM-aist-Python-${VERSION}/packages \
+ && make \
  && cp openrtm-aist* /root/${ARTIFACTS}/
 

--- a/ubuntu_1804/Dockerfile
+++ b/ubuntu_1804/Dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu:18.04 as omniorb-build
 
-ENV OMNI_TOP="omniorb-src"
-ENV OMNI_SRC="omniORB-4.2.3"
-ENV OMNI_APT_SRC="omniorb-dfsg-4.2.2"
-ENV ARTIFACTS="artifacts"
+ARG OMNI_TOP="omniorb-src"
+ARG OMNI_VER
+ARG OMNI_APT_SRC="omniorb-dfsg-4.2.2"
+ARG ARTIFACTS="artifacts"
 
 RUN apt update\
  && apt install -y --no-install-recommends \
@@ -26,10 +26,10 @@ RUN sed -i -e 's/^# deb-src/deb-src/g' /etc/apt/sources.list \
 COPY ${OMNI_TOP} /root/${OMNI_TOP}
 WORKDIR /root/${OMNI_TOP}
 RUN apt source omniorb \
- && cp -r ${OMNI_APT_SRC}/debian ${OMNI_SRC}/ \
- && patch -d ${OMNI_SRC}/debian < ${OMNI_SRC}_debian.patch 
+ && cp -r ${OMNI_APT_SRC}/debian omniORB-${OMNI_VER}/ \
+ && patch -d omniORB-${OMNI_VER}/debian < omniORB-${OMNI_VER}_debian.patch
 
-WORKDIR /root/${OMNI_TOP}/${OMNI_SRC}
+WORKDIR /root/${OMNI_TOP}/omniORB-${OMNI_VER}
 RUN dpkg-buildpackage -b -us -uc 
 
 RUN mkdir -p /root/${ARTIFACTS} \
@@ -39,19 +39,18 @@ RUN mkdir -p /root/${ARTIFACTS} \
  && cp /root/${OMNI_TOP}/lib*.deb /root/${ARTIFACTS}/
 
 WORKDIR /root/${ARTIFACTS}
-RUN dpkg -i libomnithread4_4.2.3-0.1_amd64.deb \
- && dpkg -i libomniorb4-2_4.2.3-0.1_amd64.deb \
- && dpkg -i libomnithread4-dev_4.2.3-0.1_amd64.deb \
- && dpkg -i libomniorb4-dev_4.2.3-0.1_amd64.deb \
- && dpkg -i omniidl_4.2.3-0.1_amd64.deb \
- && dpkg -i omniorb-nameserver_4.2.3-0.1_amd64.deb \
- && dpkg -i omniorb-idl_4.2.3-0.1_all.deb
+RUN dpkg -i libomnithread4_${OMNI_VER}*.deb \
+ && dpkg -i libomniorb4-2_${OMNI_VER}*.deb \
+ && dpkg -i libomnithread4-dev_${OMNI_VER}*.deb \
+ && dpkg -i libomniorb4-dev_${OMNI_VER}*.deb \
+ && dpkg -i omniidl_${OMNI_VER}*.deb \
+ && dpkg -i omniorb-nameserver_${OMNI_VER}*.deb \
+ && dpkg -i omniorb-idl_${OMNI_VER}*.deb
 
 ##### build omniORBpy
 
-ENV OMNIPY_TOP="omniorbpy-src"
-ENV OMNIPY_SRC="omniORBpy-4.2.3"
-ENV OMNIPY_APT_SRC="python-omniorb-4.2.2"
+ARG OMNIPY_TOP="omniorbpy-src"
+ARG OMNIPY_APT_SRC="python-omniorb-4.2.2"
 
 RUN apt install -y --no-install-recommends \
  python-all-dev \
@@ -60,10 +59,10 @@ RUN apt install -y --no-install-recommends \
 COPY ${OMNIPY_TOP} /root/${OMNIPY_TOP}
 WORKDIR /root/${OMNIPY_TOP}
 RUN apt source python-omniorb \
- && cp -r ${OMNIPY_APT_SRC}/debian ${OMNIPY_SRC}/ \
- && patch -d ${OMNIPY_SRC}/debian < ${OMNIPY_SRC}_debian.patch 
+ && cp -r ${OMNIPY_APT_SRC}/debian omniORBpy-${OMNI_VER}/ \
+ && patch -d omniORBpy-${OMNI_VER}/debian < omniORBpy-${OMNI_VER}_debian.patch 
 
-WORKDIR /root/${OMNIPY_TOP}/${OMNIPY_SRC}
+WORKDIR /root/${OMNIPY_TOP}/omniORBpy-${OMNI_VER}
 RUN dpkg-buildpackage -b -us -uc
 
 RUN cp /root/${OMNIPY_TOP}/*deb /root/${ARTIFACTS}/ \
@@ -74,13 +73,15 @@ RUN cp /root/${OMNIPY_TOP}/*deb /root/${ARTIFACTS}/ \
 
 FROM ubuntu:18.04 as openrtm-build
 
-ENV ARTIFACTS="artifacts"
+ARG ARTIFACTS="artifacts"
+ARG OMNI_VER
 
 RUN apt update\
  && apt install -y --no-install-recommends \
  python3 \
  python3-all-dev \
  doxygen \
+ graphviz \
  pkg-config \
  libssl-dev \
  build-essential \
@@ -91,12 +92,12 @@ RUN apt update\
 COPY --from=omniorb-build /root/${ARTIFACTS} /root/${ARTIFACTS}
 
 WORKDIR /root/${ARTIFACTS}
-RUN dpkg -i libomnithread4_4.2.3-0.1_amd64.deb \
- && dpkg -i libomniorb4-2_4.2.3-0.1_amd64.deb \
- && dpkg -i omniidl_4.2.3-0.1_amd64.deb \
- && dpkg -i omniidl-python3_4.2.3-0.1_all.deb \
- && dpkg -i python3-omniorb_4.2.3-0.1_amd64.deb \
- && dpkg -i python3-omniorb-omg_4.2.3-0.1_all.deb
+RUN dpkg -i libomnithread4_${OMNI_VER}*.deb \
+ && dpkg -i libomniorb4-2_${OMNI_VER}*.deb \
+ && dpkg -i omniidl_${OMNI_VER}*.deb \
+ && dpkg -i omniidl-python3_${OMNI_VER}*.deb \
+ && dpkg -i python3-omniorb_${OMNI_VER}*.deb \
+ && dpkg -i python3-omniorb-omg_${OMNI_VER}*.deb
 
 COPY OpenRTM-aist-Python /root/OpenRTM-aist-Python
 WORKDIR /root/OpenRTM-aist-Python

--- a/ubuntu_1804/Dockerfile
+++ b/ubuntu_1804/Dockerfile
@@ -76,7 +76,6 @@ FROM ubuntu:18.04 as openrtm-build
 
 ENV ARTIFACTS="artifacts"
 
-RUN sed -i -e 's%archive.ubuntu.com/ubuntu%ftp.riken.go.jp/Linux/ubuntu/%g' /etc/apt/sources.list
 RUN apt update\
  && apt install -y --no-install-recommends \
  python3 \

--- a/ubuntu_1804/Dockerfile
+++ b/ubuntu_1804/Dockerfile
@@ -1,0 +1,113 @@
+FROM ubuntu:18.04 as omniorb-build
+
+ENV OMNI_TOP="omniorb-src"
+ENV OMNI_SRC="omniORB-4.2.3"
+ENV OMNI_APT_SRC="omniorb-dfsg-4.2.2"
+ENV ARTIFACTS="artifacts"
+
+RUN apt update\
+ && apt install -y --no-install-recommends \
+ python3 \
+ python3-all-dev \
+ python3-all-dbg \
+ doxygen \
+ build-essential \
+ pkg-config \
+ libssl-dev \
+ debhelper \
+ devscripts \
+ fakeroot \
+ zlib1g-dev \
+ dpkg-dev
+
+RUN sed -i -e 's/^# deb-src/deb-src/g' /etc/apt/sources.list \
+ && apt update
+
+COPY ${OMNI_TOP} /root/${OMNI_TOP}
+WORKDIR /root/${OMNI_TOP}
+RUN apt source omniorb \
+ && cp -r ${OMNI_APT_SRC}/debian ${OMNI_SRC}/ \
+ && patch -d ${OMNI_SRC}/debian < ${OMNI_SRC}_debian.patch 
+
+WORKDIR /root/${OMNI_TOP}/${OMNI_SRC}
+RUN dpkg-buildpackage -b -us -uc 
+
+RUN mkdir -p /root/${ARTIFACTS} \
+ && cp /root/${OMNI_TOP}/omni*deb /root/${ARTIFACTS}/ \
+ && cp /root/${OMNI_TOP}/omni*buildinfo /root/${ARTIFACTS}/ \
+ && cp /root/${OMNI_TOP}/omni*changes /root/${ARTIFACTS}/ \
+ && cp /root/${OMNI_TOP}/lib*.deb /root/${ARTIFACTS}/
+
+WORKDIR /root/${ARTIFACTS}
+RUN dpkg -i libomnithread4_4.2.3-0.1_amd64.deb \
+ && dpkg -i libomniorb4-2_4.2.3-0.1_amd64.deb \
+ && dpkg -i libomnithread4-dev_4.2.3-0.1_amd64.deb \
+ && dpkg -i libomniorb4-dev_4.2.3-0.1_amd64.deb \
+ && dpkg -i omniidl_4.2.3-0.1_amd64.deb \
+ && dpkg -i omniorb-nameserver_4.2.3-0.1_amd64.deb \
+ && dpkg -i omniorb-idl_4.2.3-0.1_all.deb
+
+##### build omniORBpy
+
+ENV OMNIPY_TOP="omniorbpy-src"
+ENV OMNIPY_SRC="omniORBpy-4.2.3"
+ENV OMNIPY_APT_SRC="python-omniorb-4.2.2"
+
+RUN apt install -y --no-install-recommends \
+ python-all-dev \
+ python-all-dbg 
+
+COPY ${OMNIPY_TOP} /root/${OMNIPY_TOP}
+WORKDIR /root/${OMNIPY_TOP}
+RUN apt source python-omniorb \
+ && cp -r ${OMNIPY_APT_SRC}/debian ${OMNIPY_SRC}/ \
+ && patch -d ${OMNIPY_SRC}/debian < ${OMNIPY_SRC}_debian.patch 
+
+WORKDIR /root/${OMNIPY_TOP}/${OMNIPY_SRC}
+RUN dpkg-buildpackage -b -us -uc
+
+RUN cp /root/${OMNIPY_TOP}/*deb /root/${ARTIFACTS}/ \
+ && cp /root/${OMNIPY_TOP}/*buildinfo /root/${ARTIFACTS}/ \
+ && cp /root/${OMNIPY_TOP}/*changes /root/${ARTIFACTS}/
+
+##### build OpenRTM-aist-Python 
+
+FROM ubuntu:18.04 as openrtm-build
+
+ENV ARTIFACTS="artifacts"
+
+RUN sed -i -e 's%archive.ubuntu.com/ubuntu%ftp.riken.go.jp/Linux/ubuntu/%g' /etc/apt/sources.list
+RUN apt update\
+ && apt install -y --no-install-recommends \
+ python3 \
+ python3-all-dev \
+ doxygen \
+ pkg-config \
+ libssl-dev \
+ build-essential \
+ debhelper \
+ devscripts \
+ fakeroot
+
+COPY --from=omniorb-build /root/${ARTIFACTS} /root/${ARTIFACTS}
+
+WORKDIR /root/${ARTIFACTS}
+RUN dpkg -i libomnithread4_4.2.3-0.1_amd64.deb \
+ && dpkg -i libomniorb4-2_4.2.3-0.1_amd64.deb \
+ && dpkg -i omniidl_4.2.3-0.1_amd64.deb \
+ && dpkg -i omniidl-python3_4.2.3-0.1_all.deb \
+ && dpkg -i python3-omniorb_4.2.3-0.1_amd64.deb \
+ && dpkg -i python3-omniorb-omg_4.2.3-0.1_all.deb
+
+COPY OpenRTM-aist-Python /root/OpenRTM-aist-Python
+WORKDIR /root/OpenRTM-aist-Python
+RUN python3 setup.py build \
+ && python3 setup.py sdist
+
+WORKDIR /root/OpenRTM-aist-Python/dist
+RUN tar xf OpenRTM-aist-Python-1.2.1.tar.gz
+
+WORKDIR OpenRTM-aist-Python-1.2.1/packages
+RUN make \ 
+ && cp openrtm-aist* /root/${ARTIFACTS}/
+

--- a/ubuntu_1804/omniORB-4.2.3_debian.patch
+++ b/ubuntu_1804/omniORB-4.2.3_debian.patch
@@ -1,0 +1,23 @@
+diff -uprN debian422/changelog debian423/changelog
+--- debian422/changelog	2020-02-03 14:02:10.300723345 +0900
++++ debian423/changelog	2020-02-04 18:47:01.728671320 +0900
+@@ -1,3 +1,10 @@
++omniorb (4.2.3-0.1) experimental; urgency=medium
++
++  * Non-maintainer upload.
++  * New upstream version.
++
++ -- Noriaki Ando <n-ando@aist.go.jp>  Mon, 03 Feb 2020 14:21:30 +0100
++
+ omniorb-dfsg (4.2.2-0.8) experimental; urgency=medium
+ 
+   * Non-maintainer upload.
+diff -uprN debian422/control debian423/control
+--- debian422/control	2020-02-03 14:02:10.300723345 +0900
++++ debian423/control	2020-02-04 18:47:13.600671320 +0900
+@@ -1,4 +1,4 @@
+-Source: omniorb-dfsg
++Source: omniorb
+ Section: devel
+ Priority: optional
+ Maintainer: Debian CORBA Team <pkg-corba-devel@lists.alioth.debian.org>

--- a/ubuntu_1804/omniORBpy-4.2.3_debian.patch
+++ b/ubuntu_1804/omniORBpy-4.2.3_debian.patch
@@ -1,0 +1,163 @@
+diff -uprN debian/changelog debian_mod/changelog
+--- debian/changelog	2020-02-14 15:59:28.744900635 +0900
++++ debian_mod/changelog	2020-02-14 15:59:07.603476634 +0900
+@@ -1,3 +1,10 @@
++python-omniorb (4.2.3-0.1) experimental; urgency=medium
++
++  * Non-maintainer upload.
++  * New upstream version.
++
++ -- Noriaki Ando <n-ando@aist.go.jp>  Mon, 03 Feb 2020 14:21:30 +0100
++
+ python-omniorb (4.2.2-0.1) experimental; urgency=medium
+ 
+   * Non-maintainer upload.
+diff -uprN debian/control debian_mod/control
+--- debian/control	2020-02-14 15:59:28.744900635 +0900
++++ debian_mod/control	2020-02-14 15:59:07.603476634 +0900
+@@ -7,20 +7,20 @@ Build-Depends: debhelper (>= 9),
+   dh-python,
+   python-all-dev, python-all-dbg,
+   python3-all-dev, python3-all-dbg,
+-  libomniorb4-dev (>= 4.2.2),
+-  omniorb-idl (>= 4.2.2),
+-  omniidl (>= 4.2.2),
++  libomniorb4-dev (>= 4.2.3),
++  omniorb-idl (>= 4.2.3),
++  omniidl (>= 4.2.3),
+   autotools-dev
+-Build-Conflicts: omniidl-python
++Build-Conflicts: omniidl-python3
+ Standards-Version: 4.1.3
+ Vcs-Svn: svn://anonscm.debian.org/pkg-corba/trunk/python-omniorb
+ Vcs-Browser: http://anonscm.debian.org/viewvc/pkg-corba/trunk/python-omniorb
+ Homepage: http://omniorb.sourceforge.net
+ 
+-Package: python-omniorb
++Package: python3-omniorb
+ Architecture: any
+-Depends: ${python:Depends}, ${shlibs:Depends}, ${misc:Depends}
+-Recommends: python-omniorb-omg
++Depends: ${python3:Depends}, ${shlibs:Depends}, ${misc:Depends}
++Recommends: python3-omniorb-omg
+ Description: Python bindings for omniORB
+  omniORB4 is a freely available Common Object Request Broker
+  Architecture (CORBA) 2.6 compliant object request broker (ORB)
+@@ -31,11 +31,11 @@ Description: Python bindings for omniORB
+  This is the Debian package of omniORBpy, the Python bindings to the
+  omniORB libraries.
+ 
+-Package: python-omniorb-dbg
++Package: python3-omniorb-dbg
+ Priority: optional
+ Architecture: any
+-Depends: python-omniorb (= ${binary:Version}), ${python:Depends}, ${shlibs:Depends}, ${misc:Depends}
+-Recommends: python-dbg
++Depends: python3-omniorb (= ${binary:Version}), ${python3:Depends}, ${shlibs:Depends}, ${misc:Depends}
++Recommends: python3-dbg
+ Section: debug
+ Description: Python bindings for omniORB
+  omniORB4 is a freely available Common Object Request Broker
+@@ -47,7 +47,7 @@ Description: Python bindings for omniORB
+  This package contains the debug symbols of python-omniorb as well as
+  modules for use with python-dbg.
+ 
+-Package: python-omniorb-doc
++Package: python3-omniorb-doc
+ Architecture: all
+ Depends: ${misc:Depends}
+ Section: doc
+@@ -62,10 +62,10 @@ Description: omniORBpy documentation
+  bindings to omniORB.  The bindings themselves can be found in the
+  python-omniorb package.
+  
+-Package: python-omniorb-omg
++Package: python3-omniorb-omg
+ Architecture: all
+-Depends: python-omniorb (>= ${binary:Version}), ${python:Depends}, ${misc:Depends}
+-Conflicts: python-pyorbit-omg
++Depends: python3-omniorb (>= ${binary:Version}), ${python3:Depends}, ${misc:Depends}
++#Conflicts: python-pyorbit-omg
+ Description: CORBA OMG standard files for python-omniorb
+  omniORB4 is a freely available Common Object Request Broker
+  Architecture (CORBA) 2.6 compliant object request broker (ORB)
+@@ -78,10 +78,12 @@ Description: CORBA OMG standard files fo
+  python-pyorbit-omg since only one package can provide the default
+  CORBA bindings.
+ 
+-Package: omniidl-python
++Package: omniidl-python3
+ Architecture: all
+-Depends: omniidl, ${python:Depends}, ${misc:Depends}
+-Recommends: python-omniorb
++Depends: omniidl, ${python3:Depends}, ${misc:Depends}
++Conflicts: omniidl-python
++Replaces: omniidl-python
++Recommends: python3-omniorb
+ Description: omniidl backend to compile Python stubs from IDL files
+  omniORB4 is a freely available Common Object Request Broker
+  Architecture (CORBA) 2.6 compliant object request broker (ORB)
+diff -uprN debian/omniidl-python3.install debian_mod/omniidl-python3.install
+--- debian/omniidl-python3.install	1970-01-01 09:00:00.000000000 +0900
++++ debian_mod/omniidl-python3.install	2020-02-14 15:59:07.603476634 +0900
+@@ -0,0 +1 @@
++usr/lib/python*/*-packages/omniidl_be/python.py usr/lib/omniidl/omniidl_be/
+diff -uprN debian/python3-omniorb-omg.install debian_mod/python3-omniorb-omg.install
+--- debian/python3-omniorb-omg.install	1970-01-01 09:00:00.000000000 +0900
++++ debian_mod/python3-omniorb-omg.install	2020-02-14 15:59:07.603476634 +0900
+@@ -0,0 +1,2 @@
++usr/lib/python*/*-packages/*.py
++usr/lib/python*/*-packages/CosNaming*
+diff -uprN debian/python3-omniorb.install debian_mod/python3-omniorb.install
+--- debian/python3-omniorb.install	1970-01-01 09:00:00.000000000 +0900
++++ debian_mod/python3-omniorb.install	2020-02-14 15:59:07.603476634 +0900
+@@ -0,0 +1,3 @@
++usr/lib/python*/*-packages/omniORB.pth
++usr/lib/python*/*-packages/_omni*-??m-*.so*
++usr/lib/python*/*-packages/omniORB/
+diff -uprN debian/rules debian_mod/rules
+--- debian/rules	2020-02-14 15:59:28.748898635 +0900
++++ debian_mod/rules	2020-02-14 15:59:07.603476634 +0900
+@@ -23,7 +23,7 @@ ifeq (,$(findstring noopt,$(DEB_BUILD_OP
+   CXX += -O2
+ endif
+ 
+-PYVERS := $(shell pyversions -vr debian/control)
++PYVERS := $(shell py3versions -vr debian/control)
+ 
+ CONFIGURE = \
+ 	CC="$(CC)" CXX="$(CXX)" ../configure $(confflags) \
+@@ -86,9 +86,9 @@ install: build
+ 	done
+ 	find . -name "*.pyc" -exec rm {} \;
+ 	find debian/tmp* -name '_omni*.so*'
+-	for i in $$(find debian/tmp-dbg -name '_omni*._d.so*'); do \
++	for i in $$(find debian/tmp-dbg -name '_omni*dm-*.so*'); do \
+ 	  echo "Renaming $$i ..."; \
+-	  dst=$$(echo $$i | sed 's,tmp-dbg,tmp,;s/\._d\.so/_d.so/'); \
++	  dst=$$(echo $$i | sed 's,tmp-dbg,tmp,;'); \
+ 	  mv $$i $$dst; \
+ 	done
+ 	find debian/tmp -name '_omni*.so*'
+@@ -102,7 +102,7 @@ binary-indep: build install
+ 	dh_installdocs -i
+ 	dh_installexamples -i
+ 	dh_installchangelogs update.log -i
+-	dh_python2 -i
++	dh_python3 -i
+ 	dh_link -i
+ 	dh_compress -i -X.pdf
+ 	dh_fixperms -i
+@@ -117,8 +117,10 @@ binary-arch: build install
+ 	dh_testroot -a
+ 	dh_installdocs -a
+ 	dh_installchangelogs update.log -a
+-	dh_python2 -a
+-	dh_strip -ppython-omniorb --dbg-package=python-omniorb-dbg
++	#dh_python2 -a
++	mv debian/python3-omniorb/usr/lib/python$(PYVERS)/site-packages debian/python3-omniorb/usr/lib/python$(PYVERS)/dist-packages
++	mv debian/python3-omniorb/usr/lib/python$(PYVERS) debian/python3-omniorb/usr/lib/python3
++	dh_strip -ppython3-omniorb --dbg-package=python3-omniorb-dbg
+ 	dh_link -a
+ 	dh_compress -a
+ 	dh_fixperms -a

--- a/ubuntu_1804/u1804-build.sh
+++ b/ubuntu_1804/u1804-build.sh
@@ -58,7 +58,7 @@ git checkout svn/RELENG_1_2
 cd -
 
 # Source build in docker environment.
-echo "${password}" | sudo -S docker build -t ${IMAGE_NAME} .
+echo "${password}" | sudo -S docker build --build-arg OMNI_VER=${OMNI_VER} -t ${IMAGE_NAME} .
 echo "${password}" | sudo -S docker create --name ${CONTAINER_NAME} ${IMAGE_NAME}
 echo "${password}" | sudo -S docker cp ${CONTAINER_NAME}:/root/artifacts .
 echo "${password}" | sudo -S docker rm ${CONTAINER_NAME}

--- a/ubuntu_1804/u1804-build.sh
+++ b/ubuntu_1804/u1804-build.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+#
+# Script to build omniORB 4.2.3, omniORBpy 4.2.3 and OpenRTM-aist-Python
+# in python3 environment of ubuntu 18.04.
+#
+# Patch the debian directory of omniORB omniORBpy 4.2.2.
+# Use this to create a deb package for omniORB and omniORBpy 4.2.3
+# in docker environment.
+# After that, create a deb package for Python3 of OpenRTM-aist-Python.
+#
+# Usage:
+#   $ sh u1804-build.sh
+#   $ ls artifacts
+#   libcos4-2_4.2.3-0.1_amd64.deb   libomnithread4-dev_4.2.3-0.1_amd64.deb
+#   omniidl_4.2.3-0.1_amd64.deb     omniorb_4.2.3-0.1_amd64.deb
+#      :
+#   openrtm-aist-python3_1.2.1-1_amd64.deb
+#
+TARGET=omniorb
+OMNI_VER=4.2.3
+DIST_NAME=ubuntu1804
+
+OMNI_SHORT_VER=`echo ${OMNI_VER} | sed 's/\.//g'`
+IMAGE_NAME=${TARGET}${OMNI_SHORT_VER}-${DIST_NAME}
+OMNI_SRC_DIR=${TARGET}-src
+OMNIPY_SRC_DIR=${TARGET}py-src
+CONTAINER_NAME=rtm-${DIST_NAME}
+
+printf "sudo password: "
+stty -echo
+read password
+stty echo
+if test -d ${OMNI_SRC_DIR}; then
+  rm -rf ${OMNI_SRC_DIR}
+fi
+mkdir ${OMNI_SRC_DIR}
+if test -d ${OMNIPY_SRC_DIR}; then
+  rm -rf ${OMNIPY_SRC_DIR}
+fi
+mkdir ${OMNIPY_SRC_DIR}
+
+##----- omniORB
+cd ${OMNI_SRC_DIR}
+wget -O- https://sourceforge.net/projects/omniorb/files/omniORB/omniORB-${OMNI_VER}/omniORB-${OMNI_VER}.tar.bz2 | tar jxvf -
+cp ../omniORB-${OMNI_VER}*.patch .
+cd -
+
+##---- omniORBpy
+cd ${OMNIPY_SRC_DIR}
+wget -O- https://sourceforge.net/projects/omniorb/files/omniORBpy/omniORBpy-${OMNI_VER}/omniORBpy-${OMNI_VER}.tar.bz2 | tar jxvf -
+cp ../omniORBpy-${OMNI_VER}*.patch .
+cd -
+
+##---- OpenRTM-aist-Python
+git clone https://github.com/OpenRTM/OpenRTM-aist-Python
+cd OpenRTM-aist-Python
+git checkout svn/RELENG_1_2
+cd -
+
+# Source build in docker environment.
+echo "${password}" | sudo -S docker build -t ${IMAGE_NAME} .
+echo "${password}" | sudo -S docker create --name ${CONTAINER_NAME} ${IMAGE_NAME}
+echo "${password}" | sudo -S docker cp ${CONTAINER_NAME}:/root/artifacts .
+echo "${password}" | sudo -S docker rm ${CONTAINER_NAME}


### PR DESCRIPTION
- Ubuntu18.04 + Python3.6環境用の omniORB4.2.3、omniORBpy4.2.3と、OpenRTM-aist-Python 1.2 の deb パッケージを一括作成するスクリプトです
- omniORBとomniORBpyのdebパッケージは、apt source で取得できるバージョン4.2.2のdebianディレクトリにパッチを当てて生成しています
- 下記の操作でdebパッケージを生成できます
```
$ sh u1804-build.sh
$ ls artifacts/
libcos4-2-dbg_4.2.3-0.1_amd64.deb       omniidl_4.2.3-0.1_amd64.deb                     openrtm-aist-python3_1.2.1-1_amd64.deb
libcos4-2_4.2.3-0.1_amd64.deb           omniorb-dbgsym_4.2.3-0.1_amd64.ddeb             openrtm-aist-python_1.2.1-1.dsc
libcos4-dev_4.2.3-0.1_amd64.deb         omniorb-doc_4.2.3-0.1_all.deb                   openrtm-aist-python_1.2.1-1.tar.gz
libomniorb4-2-dbg_4.2.3-0.1_amd64.deb   omniorb-idl_4.2.3-0.1_all.deb                   openrtm-aist-python_1.2.1-1_amd64.changes
libomniorb4-2_4.2.3-0.1_amd64.deb       omniorb-nameserver-dbgsym_4.2.3-0.1_amd64.ddeb  python-omniorb_4.2.3-0.1_amd64.buildinfo
libomniorb4-dev_4.2.3-0.1_amd64.deb     omniorb-nameserver_4.2.3-0.1_amd64.deb          python-omniorb_4.2.3-0.1_amd64.changes
libomnithread4-dbg_4.2.3-0.1_amd64.deb  omniorb_4.2.3-0.1_amd64.buildinfo               python3-omniorb-dbg_4.2.3-0.1_amd64.deb
libomnithread4-dev_4.2.3-0.1_amd64.deb  omniorb_4.2.3-0.1_amd64.changes                 python3-omniorb-doc_4.2.3-0.1_all.deb
libomnithread4_4.2.3-0.1_amd64.deb      omniorb_4.2.3-0.1_amd64.deb                     python3-omniorb-omg_4.2.3-0.1_all.deb
omniidl-dbgsym_4.2.3-0.1_amd64.ddeb     openrtm-aist-python3-doc_1.2.1-1_all.deb        python3-omniorb_4.2.3-0.1_amd64.deb
omniidl-python3_4.2.3-0.1_all.deb       openrtm-aist-python3-example_1.2.1-1_amd64.deb
```