### PR TITLE
Raspbian buster用のomniORB/omniORBpy4.2.3のdebパッケージ作成スクリプトを登録

### DIFF
--- a/raspbian-buster/omniORB-4.2.3_debian.patch
+++ b/raspbian-buster/omniORB-4.2.3_debian.patch
@@ -1,0 +1,23 @@
+diff -uprN debian422/changelog debian423/changelog
+--- debian422/changelog	2020-03-25 06:06:18.000000000 +0000
++++ debian423/changelog	2020-03-25 06:12:22.000000000 +0000
+@@ -1,3 +1,10 @@
++omniorb (4.2.3-0.1) experimental; urgency=medium
++
++  * Non-maintainer upload.
++  * New upstream version. 
++
++ -- Noriaki Ando <n-ando@aist.go.jp>  Wed, 25 Mar 2020 06:06:53 +0000
++
+ omniorb-dfsg (4.2.2-0.9) unstable; urgency=medium
+ 
+   * Non-maintainer upload.
+diff -uprN debian422/control debian423/control
+--- debian422/control	2020-03-25 06:06:18.000000000 +0000
++++ debian423/control	2020-03-25 06:12:22.000000000 +0000
+@@ -1,4 +1,4 @@
+-Source: omniorb-dfsg
++Source: omniorb
+ Section: devel
+ Priority: optional
+ Maintainer: Debian CORBA Team <pkg-corba-devel@lists.alioth.debian.org>

--- a/raspbian-buster/omniORBpy-4.2.3_debian.patch
+++ b/raspbian-buster/omniORBpy-4.2.3_debian.patch
@@ -1,0 +1,163 @@
+diff -uprN debian422/changelog debian423/changelog
+--- debian422/changelog	2020-03-25 10:19:54.000000000 +0000
++++ debian423/changelog	2020-03-25 10:53:10.000000000 +0000
+@@ -1,3 +1,10 @@
++python-omniorb (4.2.3-0.1) experimental; urgency=medium
++
++  * Non-maintainer upload.
++  * New upstream version.
++
++ -- Noriaki Ando <n-ando@aist.go.jp>  Wed, 25 Mar 2020 10:21:52 +0000
++
+ python-omniorb (4.2.2-0.2) unstable; urgency=medium
+ 
+   * Non-maintainer upload.
+diff -uprN debian422/control debian423/control
+--- debian422/control	2020-03-25 10:19:54.000000000 +0000
++++ debian423/control	2020-03-25 10:53:10.000000000 +0000
+@@ -7,20 +7,20 @@ Build-Depends: debhelper (>= 9),
+   dh-python,
+   python-all-dev, python-all-dbg,
+   python3-all-dev, python3-all-dbg,
+-  libomniorb4-dev (>= 4.2.2),
+-  omniorb-idl (>= 4.2.2),
+-  omniidl (>= 4.2.2),
++  libomniorb4-dev (>= 4.2.3),
++  omniorb-idl (>= 4.2.3),
++  omniidl (>= 4.2.3),
+   autotools-dev
+-Build-Conflicts: omniidl-python
++Build-Conflicts: omniidl-python3
+ Standards-Version: 4.1.3
+ Vcs-Svn: svn://anonscm.debian.org/pkg-corba/trunk/python-omniorb
+ Vcs-Browser: http://anonscm.debian.org/viewvc/pkg-corba/trunk/python-omniorb
+ Homepage: http://omniorb.sourceforge.net
+ 
+-Package: python-omniorb
++Package: python3-omniorb
+ Architecture: any
+-Depends: ${python:Depends}, ${shlibs:Depends}, ${misc:Depends}
+-Recommends: python-omniorb-omg
++Depends: ${python3:Depends}, ${shlibs:Depends}, ${misc:Depends}
++Recommends: python3-omniorb-omg
+ Description: Python bindings for omniORB
+  omniORB4 is a freely available Common Object Request Broker
+  Architecture (CORBA) 2.6 compliant object request broker (ORB)
+@@ -31,11 +31,11 @@ Description: Python bindings for omniORB
+  This is the Debian package of omniORBpy, the Python bindings to the
+  omniORB libraries.
+ 
+-Package: python-omniorb-dbg
++Package: python3-omniorb-dbg
+ Priority: optional
+ Architecture: any
+-Depends: python-omniorb (= ${binary:Version}), ${python:Depends}, ${shlibs:Depends}, ${misc:Depends}
+-Recommends: python-dbg
++Depends: python3-omniorb (= ${binary:Version}), ${python:Depends}, ${shlibs:Depends}, ${misc:Depends}
++Recommends: python3-dbg
+ Section: debug
+ Description: Python bindings for omniORB
+  omniORB4 is a freely available Common Object Request Broker
+@@ -47,7 +47,7 @@ Description: Python bindings for omniORB
+  This package contains the debug symbols of python-omniorb as well as
+  modules for use with python-dbg.
+ 
+-Package: python-omniorb-doc
++Package: python3-omniorb-doc
+ Architecture: all
+ Depends: ${misc:Depends}
+ Section: doc
+@@ -62,10 +62,10 @@ Description: omniORBpy documentation
+  bindings to omniORB.  The bindings themselves can be found in the
+  python-omniorb package.
+  
+-Package: python-omniorb-omg
++Package: python3-omniorb-omg
+ Architecture: all
+-Depends: python-omniorb (>= ${binary:Version}), ${python:Depends}, ${misc:Depends}
+-Conflicts: python-pyorbit-omg
++Depends: python3-omniorb (>= ${binary:Version}), ${python:Depends}, ${misc:Depends}
++#Conflicts: python-pyorbit-omg
+ Description: CORBA OMG standard files for python-omniorb
+  omniORB4 is a freely available Common Object Request Broker
+  Architecture (CORBA) 2.6 compliant object request broker (ORB)
+@@ -78,10 +78,12 @@ Description: CORBA OMG standard files fo
+  python-pyorbit-omg since only one package can provide the default
+  CORBA bindings.
+ 
+-Package: omniidl-python
++Package: omniidl-python3
+ Architecture: all
+-Depends: omniidl, ${python:Depends}, ${misc:Depends}
+-Recommends: python-omniorb
++Depends: omniidl, ${python3:Depends}, ${misc:Depends}
++Conflicts: omniidl-python
++Replaces: omniidl-python
++Recommends: python3-omniorb
+ Description: omniidl backend to compile Python stubs from IDL files
+  omniORB4 is a freely available Common Object Request Broker
+  Architecture (CORBA) 2.6 compliant object request broker (ORB)
+diff -uprN debian422/omniidl-python3.install debian423/omniidl-python3.install
+--- debian422/omniidl-python3.install	1970-01-01 01:00:00.000000000 +0100
++++ debian423/omniidl-python3.install	2020-03-25 10:53:10.000000000 +0000
+@@ -0,0 +1 @@
++usr/lib/python*/*-packages/omniidl_be/python.py usr/lib/omniidl/omniidl_be/
+diff -uprN debian422/python3-omniorb-omg.install debian423/python3-omniorb-omg.install
+--- debian422/python3-omniorb-omg.install	1970-01-01 01:00:00.000000000 +0100
++++ debian423/python3-omniorb-omg.install	2020-03-25 10:53:10.000000000 +0000
+@@ -0,0 +1,2 @@
++usr/lib/python*/*-packages/*.py
++usr/lib/python*/*-packages/CosNaming*
+diff -uprN debian422/python3-omniorb.install debian423/python3-omniorb.install
+--- debian422/python3-omniorb.install	1970-01-01 01:00:00.000000000 +0100
++++ debian423/python3-omniorb.install	2020-03-25 10:53:10.000000000 +0000
+@@ -0,0 +1,3 @@
++usr/lib/python*/*-packages/omniORB.pth
++usr/lib/python*/*-packages/_omni*-??m-*.so*
++usr/lib/python*/*-packages/omniORB/
+diff -uprN debian422/rules debian423/rules
+--- debian422/rules	2020-03-25 10:19:54.000000000 +0000
++++ debian423/rules	2020-03-25 10:53:10.000000000 +0000
+@@ -23,7 +23,7 @@ ifeq (,$(findstring noopt,$(DEB_BUILD_OP
+   CXX += -O2
+ endif
+ 
+-PYVERS := $(shell pyversions -vr debian/control)
++PYVERS := $(shell py3versions -vr debian/control)
+ 
+ CONFIGURE = \
+ 	CC="$(CC)" CXX="$(CXX)" ../configure $(confflags) \
+@@ -86,9 +86,9 @@ install: build
+ 	done
+ 	find . -name "*.pyc" -exec rm {} \;
+ 	find debian/tmp* -name '_omni*.so*'
+-	for i in $$(find debian/tmp-dbg -name '_omni*._d.so*'); do \
++	for i in $$(find debian/tmp-dbg -name '_omni*dm-*.so*'); do \
+ 	  echo "Renaming $$i ..."; \
+-	  dst=$$(echo $$i | sed 's,tmp-dbg,tmp,;s/\._d\.so/_d.so/'); \
++	  dst=$$(echo $$i | sed 's,tmp-dbg,tmp,;'); \
+ 	  mv $$i $$dst; \
+ 	done
+ 	find debian/tmp -name '_omni*.so*'
+@@ -102,7 +102,7 @@ binary-indep: build install
+ 	dh_installdocs -i
+ 	dh_installexamples -i
+ 	dh_installchangelogs update.log -i
+-	dh_python2 -i
++	dh_python3 -i
+ 	dh_link -i
+ 	dh_compress -i -X.pdf
+ 	dh_fixperms -i
+@@ -117,8 +117,10 @@ binary-arch: build install
+ 	dh_testroot -a
+ 	dh_installdocs -a
+ 	dh_installchangelogs update.log -a
+-	dh_python2 -a
+-	dh_strip -ppython-omniorb --dbg-package=python-omniorb-dbg
++	#dh_python2 -a
++	mv debian/python3-omniorb/usr/lib/python$(PYVERS)/site-packages debian/python3-omniorb/usr/lib/python$(PYVERS)/dist-packages
++	mv debian/python3-omniorb/usr/lib/python$(PYVERS) debian/python3-omniorb/usr/lib/python3
++	dh_strip -ppython3-omniorb --dbg-package=python3-omniorb-dbg
+ 	dh_link -a
+ 	dh_compress -a
+ 	dh_fixperms -a

--- a/raspbian-buster/raspi-build.sh
+++ b/raspbian-buster/raspi-build.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+#
+# Script to build omniORB 4.2.3, omniORBpy 4.2.3 and OpenRTM-aist-Python
+# in python3 environment of Raspberry Pi.
+#
+# Patch the debian directory of omniORB omniORBpy 4.2.2.
+# Use this to create a deb package for omniORB and omniORBpy 4.2.3
+# in docker environment.
+# After that, create a deb package for Python3 of OpenRTM-aist-Python.
+#
+# Usage:
+#   $ sh raspi-build.sh 
+#   $ ls artifacts
+#   libcos4-2_4.2.3-0.1_armhf.deb   libomnithread4-dev_4.2.3-0.1_armhf.deb
+#   omniidl_4.2.3-0.1_armhf.deb     omniorb_4.2.3-0.1_armhf.deb
+#      :
+#   openrtm-aist-python3_1.2.1-1_armhf.deb
+#
+TARGET=omniorb
+OMNI_VER=4.2.3
+DIST_NAME=raspi_buster
+OMNI_APT_SRC="omniorb-dfsg-4.2.2"
+OMNIPY_APT_SRC="python-omniorb-4.2.2"
+ARTIFACTS="artifacts"
+
+OMNI_SHORT_VER=`echo ${OMNI_VER} | sed 's/\.//g'`
+IMAGE_NAME=${TARGET}${OMNI_SHORT_VER}-${DIST_NAME}
+OMNI_SRC_DIR=${TARGET}-src
+OMNIPY_SRC_DIR=${TARGET}py-src
+TOP_DIR=`pwd`
+
+if test -d ${OMNI_SRC_DIR}; then
+  rm -rf ${OMNI_SRC_DIR}
+fi
+mkdir ${OMNI_SRC_DIR}
+
+if test -d ${OMNIPY_SRC_DIR}; then
+  rm -rf ${OMNIPY_SRC_DIR}
+fi
+mkdir ${OMNIPY_SRC_DIR}
+
+mkdir ${ARTIFACTS}
+if test -d ${ARTIFACTS}; then
+  rm -rf ${ARTIFACTS}
+fi
+mkdir ${ARTIFACTS}
+
+apt install -y python3-all-dev python3-all-dbg doxygen 
+apt install -y build-essential debhelper devscripts dpkg-dev
+apt install -y libssl-dev python-all-dbg
+
+
+##----- omniORB
+cd ${OMNI_SRC_DIR}
+wget -O- https://sourceforge.net/projects/omniorb/files/omniORB/omniORB-${OMNI_VER}/omniORB-${OMNI_VER}.tar.bz2 | tar jxvf -
+apt source omniorb
+cp -r ${OMNI_APT_SRC}/debian omniORB-${OMNI_VER}/
+patch -d omniORB-${OMNI_VER}/debian < ../omniORB-${OMNI_VER}_debian.patch
+cd omniORB-${OMNI_VER} 
+dpkg-buildpackage -b -us -uc
+cd -
+
+cp omni*deb ${TOP_DIR}/${ARTIFACTS}/
+cp omni*buildinfo ${TOP_DIR}/${ARTIFACTS}/
+cp omni*changes ${TOP_DIR}/${ARTIFACTS}/
+cp lib*.deb ${TOP_DIR}/${ARTIFACTS}/
+
+dpkg -i libomnithread4_${OMNI_VER}*.deb
+dpkg -i libomniorb4-2_${OMNI_VER}*.deb
+dpkg -i libomnithread4-dev_${OMNI_VER}*.deb
+dpkg -i libomniorb4-dev_${OMNI_VER}*.deb
+dpkg -i omniidl_${OMNI_VER}*.deb
+dpkg -i omniorb-nameserver_${OMNI_VER}*.deb
+dpkg -i omniorb-idl_${OMNI_VER}*.deb
+cd -
+
+##---- omniORBpy
+cd ${OMNIPY_SRC_DIR}
+wget -O- https://sourceforge.net/projects/omniorb/files/omniORBpy/omniORBpy-${OMNI_VER}/omniORBpy-${OMNI_VER}.tar.bz2 | tar jxvf -
+apt source python-omniorb
+cp -r ${OMNIPY_APT_SRC}/debian omniORBpy-${OMNI_VER}/
+patch -d omniORBpy-${OMNI_VER}/debian < ../omniORBpy-${OMNI_VER}_debian.patch 
+cd omniORBpy-${OMNI_VER}
+dpkg-buildpackage -b -us -uc
+cd -
+
+cp *deb ${TOP_DIR}/${ARTIFACTS}/
+cp *buildinfo ${TOP_DIR}/${ARTIFACTS}/
+cp *changes ${TOP_DIR}/${ARTIFACTS}/
+
+dpkg -i omniidl-python3_${OMNI_VER}*.deb
+dpkg -i python3-omniorb_${OMNI_VER}*.deb
+dpkg -i python3-omniorb-omg_${OMNI_VER}*.deb
+cd -
+
+##---- OpenRTM-aist-Python
+git clone https://github.com/OpenRTM/OpenRTM-aist-Python
+cd OpenRTM-aist-Python
+git checkout svn/RELENG_1_2
+
+python3 setup.py build
+python3 setup.py sdist
+
+cd dist
+VERSION=`python3 ../setup.py --version`
+tar xf OpenRTM-aist-Python-${VERSION}.tar.gz
+cd OpenRTM-aist-Python-${VERSION}/packages
+make
+cp openrtm-aist* ${TOP_DIR}/${ARTIFACTS}/
+
+cd ${TOP_DIR}
+


### PR DESCRIPTION
Link to #3 

- Raspbianの公式Dockerイメージは提供されていないので、QEMU環境を利用してビルドした
- 生成したomniORB, omniORBpy, OpenRTM-aist-Python 1.2, rtshell-aist をインストールし、サンプルRTCの接続動作を確認した
```
# sh raspi-build.sh
# ls artifacts/*.deb
libcos4-2-dbg_4.2.3-0.1_armhf.deb       omniidl-dbgsym_4.2.3-0.1_armhf.deb            openrtm-aist-python3-doc_1.2.1-1_all.deb
libcos4-2_4.2.3-0.1_armhf.deb           omniidl-python3_4.2.3-0.1_all.deb             openrtm-aist-python3-example_1.2.1-1_armhf.deb
libcos4-dev_4.2.3-0.1_armhf.deb         omniidl_4.2.3-0.1_armhf.deb                   openrtm-aist-python3_1.2.1-1_armhf.deb
libomniorb4-2-dbg_4.2.3-0.1_armhf.deb   omniorb-dbgsym_4.2.3-0.1_armhf.deb            python3-omniorb-dbg_4.2.3-0.1_armhf.deb
libomniorb4-2_4.2.3-0.1_armhf.deb       omniorb-doc_4.2.3-0.1_all.deb                 python3-omniorb-doc_4.2.3-0.1_all.deb
libomniorb4-dev_4.2.3-0.1_armhf.deb     omniorb-idl_4.2.3-0.1_all.deb                 python3-omniorb-omg_4.2.3-0.1_all.deb
libomnithread4-dbg_4.2.3-0.1_armhf.deb  omniorb-nameserver-dbgsym_4.2.3-0.1_armhf.deb python3-omniorb_4.2.3-0.1_armhf.deb
libomnithread4-dev_4.2.3-0.1_armhf.deb  omniorb-nameserver_4.2.3-0.1_armhf.deb
libomnithread4_4.2.3-0.1_armhf.deb      omniorb_4.2.3-0.1_armhf.deb
```

- rtshell-aistをインストールして ConsoleIn.py, ConsoleOut.py の接続動作を確認した
```
# pip3 install rtshell-aist
# pip3 show rtshell-aist
　　：
Location: /usr/local/lib/python3.7/dist-packages
```
- RTCの接続動作確認
- QEMU環境なので、別々のコンソール画面から sudo chroot で接続してRTCを起動し、ConsoleInで入力した数値がConsoleOut画面に表示されることを確認した
```
# python3 /usr/lib/python3/dist-packages/OpenRTM_aist/utils/rtm-naming/rtm-naming.py &
# python3 /usr/share/openrtm-1.2/components/python3/SimpleIO/ConsoleIn.py
# python3 /usr/share/openrtm-1.2/components/python3/SimpleIO/ConsoleOut.py

# rtls localhost/u1804-kawa.host_cxt/
ConsoleIn0.rtc  ConsoleOut0.rtc

# rtcon /localhost/u1804-kawa.host_cxt/ConsoleIn0.rtc:out /localhost/u1804-kawa.host_cxt/ConsoleOut0.rtc:in -i my_connection
# rtact /localhost/u1804-kawa.host_cxt/ConsoleIn0.rtc  /localhost/u1804-kawa.host_cxt/ConsoleOut0.rtc

# rtdeact /localhost/u1804-kawa.host_cxt/ConsoleIn0.rtc  /localhost/u1804-kawa.host_cxt/ConsoleOut0.rtc
# rtexit /localhost/u1804-kawa.host_cxt/ConsoleIn0.rtc
# rtexit /localhost/u1804-kawa.host_cxt/ConsoleOut0.rtc
```



