### PR TITLE
omniORB 4.2.4 に対応する

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # omniORB_build_scripts
-Contains patches for omniORB 4.2.3 and omniORBpy 4.2.3 for creating python3 deb packages.
+Contains patches for omniORB 4.2.4 and omniORBpy 4.2.4 for creating python3 deb packages.

--- a/raspbian-buster/omniORB-4.2.4_debian.patch
+++ b/raspbian-buster/omniORB-4.2.4_debian.patch
@@ -2,7 +2,7 @@ diff -uprN debian422/changelog debian423/changelog
 --- debian422/changelog	2020-03-25 06:06:18.000000000 +0000
 +++ debian423/changelog	2020-03-25 06:12:22.000000000 +0000
 @@ -1,3 +1,10 @@
-+omniorb (4.2.3-0.1) experimental; urgency=medium
++omniorb (4.2.4-0.1) experimental; urgency=medium
 +
 +  * Non-maintainer upload.
 +  * New upstream version. 

--- a/raspbian-buster/omniORBpy-4.2.4_debian.patch
+++ b/raspbian-buster/omniORBpy-4.2.4_debian.patch
@@ -1,20 +1,20 @@
-diff -uprN debian/changelog debian_mod/changelog
---- debian/changelog	2020-02-14 15:59:28.744900635 +0900
-+++ debian_mod/changelog	2020-02-14 15:59:07.603476634 +0900
+diff -uprN debian422/changelog debian423/changelog
+--- debian422/changelog	2020-03-25 10:19:54.000000000 +0000
++++ debian423/changelog	2020-03-25 10:53:10.000000000 +0000
 @@ -1,3 +1,10 @@
-+python-omniorb (4.2.3-0.1) experimental; urgency=medium
++python-omniorb (4.2.4-0.1) experimental; urgency=medium
 +
 +  * Non-maintainer upload.
 +  * New upstream version.
 +
-+ -- Noriaki Ando <n-ando@aist.go.jp>  Mon, 03 Feb 2020 14:21:30 +0100
++ -- Noriaki Ando <n-ando@aist.go.jp>  Wed, 25 Mar 2020 10:21:52 +0000
 +
- python-omniorb (4.2.2-0.1) experimental; urgency=medium
+ python-omniorb (4.2.2-0.2) unstable; urgency=medium
  
    * Non-maintainer upload.
-diff -uprN debian/control debian_mod/control
---- debian/control	2020-02-14 15:59:28.744900635 +0900
-+++ debian_mod/control	2020-02-14 15:59:07.603476634 +0900
+diff -uprN debian422/control debian423/control
+--- debian422/control	2020-03-25 10:19:54.000000000 +0000
++++ debian423/control	2020-03-25 10:53:10.000000000 +0000
 @@ -7,20 +7,20 @@ Build-Depends: debhelper (>= 9),
    dh-python,
    python-all-dev, python-all-dbg,
@@ -22,9 +22,9 @@ diff -uprN debian/control debian_mod/control
 -  libomniorb4-dev (>= 4.2.2),
 -  omniorb-idl (>= 4.2.2),
 -  omniidl (>= 4.2.2),
-+  libomniorb4-dev (>= 4.2.3),
-+  omniorb-idl (>= 4.2.3),
-+  omniidl (>= 4.2.3),
++  libomniorb4-dev (>= 4.2.4),
++  omniorb-idl (>= 4.2.4),
++  omniidl (>= 4.2.4),
    autotools-dev
 -Build-Conflicts: omniidl-python
 +Build-Conflicts: omniidl-python3
@@ -53,7 +53,7 @@ diff -uprN debian/control debian_mod/control
  Architecture: any
 -Depends: python-omniorb (= ${binary:Version}), ${python:Depends}, ${shlibs:Depends}, ${misc:Depends}
 -Recommends: python-dbg
-+Depends: python3-omniorb (= ${binary:Version}), ${python3:Depends}, ${shlibs:Depends}, ${misc:Depends}
++Depends: python3-omniorb (= ${binary:Version}), ${python:Depends}, ${shlibs:Depends}, ${misc:Depends}
 +Recommends: python3-dbg
  Section: debug
  Description: Python bindings for omniORB
@@ -76,7 +76,7 @@ diff -uprN debian/control debian_mod/control
  Architecture: all
 -Depends: python-omniorb (>= ${binary:Version}), ${python:Depends}, ${misc:Depends}
 -Conflicts: python-pyorbit-omg
-+Depends: python3-omniorb (>= ${binary:Version}), ${python3:Depends}, ${misc:Depends}
++Depends: python3-omniorb (>= ${binary:Version}), ${python:Depends}, ${misc:Depends}
 +#Conflicts: python-pyorbit-omg
  Description: CORBA OMG standard files for python-omniorb
   omniORB4 is a freely available Common Object Request Broker
@@ -97,27 +97,27 @@ diff -uprN debian/control debian_mod/control
  Description: omniidl backend to compile Python stubs from IDL files
   omniORB4 is a freely available Common Object Request Broker
   Architecture (CORBA) 2.6 compliant object request broker (ORB)
-diff -uprN debian/omniidl-python3.install debian_mod/omniidl-python3.install
---- debian/omniidl-python3.install	1970-01-01 09:00:00.000000000 +0900
-+++ debian_mod/omniidl-python3.install	2020-02-14 15:59:07.603476634 +0900
+diff -uprN debian422/omniidl-python3.install debian423/omniidl-python3.install
+--- debian422/omniidl-python3.install	1970-01-01 01:00:00.000000000 +0100
++++ debian423/omniidl-python3.install	2020-03-25 10:53:10.000000000 +0000
 @@ -0,0 +1 @@
 +usr/lib/python*/*-packages/omniidl_be/python.py usr/lib/omniidl/omniidl_be/
-diff -uprN debian/python3-omniorb-omg.install debian_mod/python3-omniorb-omg.install
---- debian/python3-omniorb-omg.install	1970-01-01 09:00:00.000000000 +0900
-+++ debian_mod/python3-omniorb-omg.install	2020-02-14 15:59:07.603476634 +0900
+diff -uprN debian422/python3-omniorb-omg.install debian423/python3-omniorb-omg.install
+--- debian422/python3-omniorb-omg.install	1970-01-01 01:00:00.000000000 +0100
++++ debian423/python3-omniorb-omg.install	2020-03-25 10:53:10.000000000 +0000
 @@ -0,0 +1,2 @@
 +usr/lib/python*/*-packages/*.py
 +usr/lib/python*/*-packages/CosNaming*
-diff -uprN debian/python3-omniorb.install debian_mod/python3-omniorb.install
---- debian/python3-omniorb.install	1970-01-01 09:00:00.000000000 +0900
-+++ debian_mod/python3-omniorb.install	2020-02-14 15:59:07.603476634 +0900
+diff -uprN debian422/python3-omniorb.install debian423/python3-omniorb.install
+--- debian422/python3-omniorb.install	1970-01-01 01:00:00.000000000 +0100
++++ debian423/python3-omniorb.install	2020-03-25 10:53:10.000000000 +0000
 @@ -0,0 +1,3 @@
 +usr/lib/python*/*-packages/omniORB.pth
 +usr/lib/python*/*-packages/_omni*-??m-*.so*
 +usr/lib/python*/*-packages/omniORB/
-diff -uprN debian/rules debian_mod/rules
---- debian/rules	2020-02-14 15:59:28.748898635 +0900
-+++ debian_mod/rules	2020-02-14 15:59:07.603476634 +0900
+diff -uprN debian422/rules debian423/rules
+--- debian422/rules	2020-03-25 10:19:54.000000000 +0000
++++ debian423/rules	2020-03-25 10:53:10.000000000 +0000
 @@ -23,7 +23,7 @@ ifeq (,$(findstring noopt,$(DEB_BUILD_OP
    CXX += -O2
  endif

--- a/raspbian-buster/raspi-build.sh
+++ b/raspbian-buster/raspi-build.sh
@@ -1,23 +1,23 @@
 #!/bin/bash
 #
-# Script to build omniORB 4.2.3, omniORBpy 4.2.3 and OpenRTM-aist-Python
+# Script to build omniORB 4.2.4, omniORBpy 4.2.4 and OpenRTM-aist-Python
 # in python3 environment of Raspberry Pi.
 #
 # Patch the debian directory of omniORB omniORBpy 4.2.2.
-# Use this to create a deb package for omniORB and omniORBpy 4.2.3
+# Use this to create a deb package for omniORB and omniORBpy 4.2.4
 # in docker environment.
 # After that, create a deb package for Python3 of OpenRTM-aist-Python.
 #
 # Usage:
 #   $ sh raspi-build.sh 
 #   $ ls artifacts
-#   libcos4-2_4.2.3-0.1_armhf.deb   libomnithread4-dev_4.2.3-0.1_armhf.deb
-#   omniidl_4.2.3-0.1_armhf.deb     omniorb_4.2.3-0.1_armhf.deb
+#   libcos4-2_4.2.4-0.1_armhf.deb   libomnithread4-dev_4.2.4-0.1_armhf.deb
+#   omniidl_4.2.4-0.1_armhf.deb     omniorb_4.2.4-0.1_armhf.deb
 #      :
-#   openrtm-aist-python3_1.2.1-1_armhf.deb
+#   openrtm-aist-python3_1.2.2-0_armhf.deb
 #
 TARGET=omniorb
-OMNI_VER=4.2.3
+OMNI_VER=4.2.4
 DIST_NAME=raspi_buster
 OMNI_APT_SRC="omniorb-dfsg-4.2.2"
 OMNIPY_APT_SRC="python-omniorb-4.2.2"

--- a/ubuntu_1604/omniORB-4.2.4_debian.patch
+++ b/ubuntu_1604/omniORB-4.2.4_debian.patch
@@ -2,7 +2,7 @@ diff -uprN debian/changelog debian_mod/changelog
 --- debian/changelog	2020-02-21 14:12:47.396086534 +0900
 +++ debian_mod/changelog	2020-02-21 14:16:08.303582533 +0900
 @@ -1,3 +1,10 @@
-+omniorb (4.2.3-0.1) experimental; urgency=medium
++omniorb (4.2.4-0.1) experimental; urgency=medium
 +
 +  * Non-maintainer upload.
 +  * New upstream version.

--- a/ubuntu_1604/omniORBpy-4.2.4_debian.patch
+++ b/ubuntu_1604/omniORBpy-4.2.4_debian.patch
@@ -2,7 +2,7 @@ diff -uprN debian/changelog debian_1604/changelog
 --- debian/changelog	2020-02-12 14:14:44.493119029 +0900
 +++ debian_1604/changelog	2020-02-21 15:07:56.551650533 +0900
 @@ -1,3 +1,10 @@
-+python-omniorb (4.2.3-0.1) experimental; urgency=medium
++python-omniorb (4.2.4-0.1) experimental; urgency=medium
 +
 +  * Non-maintainer upload.
 +  * New upstream version.
@@ -22,9 +22,9 @@ diff -uprN debian/control debian_1604/control
 -  libomniorb4-dev (>= 4.2.2),
 -  omniorb-idl (>= 4.2.2),
 -  omniidl (>= 4.2.2),
-+  libomniorb4-dev (>= 4.2.3),
-+  omniorb-idl (>= 4.2.3),
-+  omniidl (>= 4.2.3),
++  libomniorb4-dev (>= 4.2.4),
++  omniorb-idl (>= 4.2.4),
++  omniidl (>= 4.2.4),
    autotools-dev
 -Build-Conflicts: omniidl-python
 +Build-Conflicts: omniidl-python3

--- a/ubuntu_1604/u1604-build.sh
+++ b/ubuntu_1604/u1604-build.sh
@@ -1,23 +1,23 @@
 #!/bin/bash
 #
-# Script to build omniORB 4.2.3, omniORBpy 4.2.3 and OpenRTM-aist-Python
+# Script to build omniORB 4.2.4, omniORBpy 4.2.4 and OpenRTM-aist-Python
 # in python3 environment of ubuntu 16.04.
 #
 # Patch the debian directory of omniORB omniORBpy 4.2.2.
-# Use this to create a deb package for omniORB and omniORBpy 4.2.3
+# Use this to create a deb package for omniORB and omniORBpy 4.2.4
 # in docker environment.
 # After that, create a deb package for Python3 of OpenRTM-aist-Python.
 #
 # Usage:
 #   $ sh u1604-build.sh
 #   $ ls artifacts
-#   libcos4-2_4.2.3-0.1_amd64.deb   libomnithread4-dev_4.2.3-0.1_amd64.deb
-#   omniidl_4.2.3-0.1_amd64.deb     omniorb_4.2.3-0.1_amd64.deb
+#   libcos4-2_4.2.4-0.1_amd64.deb   libomnithread4-dev_4.2.4-0.1_amd64.deb
+#   omniidl_4.2.4-0.1_amd64.deb     omniorb_4.2.4-0.1_amd64.deb
 #      :
-#   openrtm-aist-python3_1.2.1-1_amd64.deb
+#   openrtm-aist-python3_1.2.2-0_amd64.deb
 #
 TARGET=omniorb
-OMNI_VER=4.2.3
+OMNI_VER=4.2.4
 DIST_NAME=ubuntu1604
 
 OMNI_SHORT_VER=`echo ${OMNI_VER} | sed 's/\.//g'`

--- a/ubuntu_1804/omniORB-4.2.4_debian.patch
+++ b/ubuntu_1804/omniORB-4.2.4_debian.patch
@@ -2,7 +2,7 @@ diff -uprN debian422/changelog debian423/changelog
 --- debian422/changelog	2020-02-03 14:02:10.300723345 +0900
 +++ debian423/changelog	2020-02-04 18:47:01.728671320 +0900
 @@ -1,3 +1,10 @@
-+omniorb (4.2.3-0.1) experimental; urgency=medium
++omniorb (4.2.4-0.1) experimental; urgency=medium
 +
 +  * Non-maintainer upload.
 +  * New upstream version.

--- a/ubuntu_1804/omniORBpy-4.2.4_debian.patch
+++ b/ubuntu_1804/omniORBpy-4.2.4_debian.patch
@@ -1,20 +1,20 @@
-diff -uprN debian422/changelog debian423/changelog
---- debian422/changelog	2020-03-25 10:19:54.000000000 +0000
-+++ debian423/changelog	2020-03-25 10:53:10.000000000 +0000
+diff -uprN debian/changelog debian_mod/changelog
+--- debian/changelog	2020-02-14 15:59:28.744900635 +0900
++++ debian_mod/changelog	2020-02-14 15:59:07.603476634 +0900
 @@ -1,3 +1,10 @@
-+python-omniorb (4.2.3-0.1) experimental; urgency=medium
++python-omniorb (4.2.4-0.1) experimental; urgency=medium
 +
 +  * Non-maintainer upload.
 +  * New upstream version.
 +
-+ -- Noriaki Ando <n-ando@aist.go.jp>  Wed, 25 Mar 2020 10:21:52 +0000
++ -- Noriaki Ando <n-ando@aist.go.jp>  Mon, 03 Feb 2020 14:21:30 +0100
 +
- python-omniorb (4.2.2-0.2) unstable; urgency=medium
+ python-omniorb (4.2.2-0.1) experimental; urgency=medium
  
    * Non-maintainer upload.
-diff -uprN debian422/control debian423/control
---- debian422/control	2020-03-25 10:19:54.000000000 +0000
-+++ debian423/control	2020-03-25 10:53:10.000000000 +0000
+diff -uprN debian/control debian_mod/control
+--- debian/control	2020-02-14 15:59:28.744900635 +0900
++++ debian_mod/control	2020-02-14 15:59:07.603476634 +0900
 @@ -7,20 +7,20 @@ Build-Depends: debhelper (>= 9),
    dh-python,
    python-all-dev, python-all-dbg,
@@ -22,9 +22,9 @@ diff -uprN debian422/control debian423/control
 -  libomniorb4-dev (>= 4.2.2),
 -  omniorb-idl (>= 4.2.2),
 -  omniidl (>= 4.2.2),
-+  libomniorb4-dev (>= 4.2.3),
-+  omniorb-idl (>= 4.2.3),
-+  omniidl (>= 4.2.3),
++  libomniorb4-dev (>= 4.2.4),
++  omniorb-idl (>= 4.2.4),
++  omniidl (>= 4.2.4),
    autotools-dev
 -Build-Conflicts: omniidl-python
 +Build-Conflicts: omniidl-python3
@@ -53,7 +53,7 @@ diff -uprN debian422/control debian423/control
  Architecture: any
 -Depends: python-omniorb (= ${binary:Version}), ${python:Depends}, ${shlibs:Depends}, ${misc:Depends}
 -Recommends: python-dbg
-+Depends: python3-omniorb (= ${binary:Version}), ${python:Depends}, ${shlibs:Depends}, ${misc:Depends}
++Depends: python3-omniorb (= ${binary:Version}), ${python3:Depends}, ${shlibs:Depends}, ${misc:Depends}
 +Recommends: python3-dbg
  Section: debug
  Description: Python bindings for omniORB
@@ -76,7 +76,7 @@ diff -uprN debian422/control debian423/control
  Architecture: all
 -Depends: python-omniorb (>= ${binary:Version}), ${python:Depends}, ${misc:Depends}
 -Conflicts: python-pyorbit-omg
-+Depends: python3-omniorb (>= ${binary:Version}), ${python:Depends}, ${misc:Depends}
++Depends: python3-omniorb (>= ${binary:Version}), ${python3:Depends}, ${misc:Depends}
 +#Conflicts: python-pyorbit-omg
  Description: CORBA OMG standard files for python-omniorb
   omniORB4 is a freely available Common Object Request Broker
@@ -97,27 +97,27 @@ diff -uprN debian422/control debian423/control
  Description: omniidl backend to compile Python stubs from IDL files
   omniORB4 is a freely available Common Object Request Broker
   Architecture (CORBA) 2.6 compliant object request broker (ORB)
-diff -uprN debian422/omniidl-python3.install debian423/omniidl-python3.install
---- debian422/omniidl-python3.install	1970-01-01 01:00:00.000000000 +0100
-+++ debian423/omniidl-python3.install	2020-03-25 10:53:10.000000000 +0000
+diff -uprN debian/omniidl-python3.install debian_mod/omniidl-python3.install
+--- debian/omniidl-python3.install	1970-01-01 09:00:00.000000000 +0900
++++ debian_mod/omniidl-python3.install	2020-02-14 15:59:07.603476634 +0900
 @@ -0,0 +1 @@
 +usr/lib/python*/*-packages/omniidl_be/python.py usr/lib/omniidl/omniidl_be/
-diff -uprN debian422/python3-omniorb-omg.install debian423/python3-omniorb-omg.install
---- debian422/python3-omniorb-omg.install	1970-01-01 01:00:00.000000000 +0100
-+++ debian423/python3-omniorb-omg.install	2020-03-25 10:53:10.000000000 +0000
+diff -uprN debian/python3-omniorb-omg.install debian_mod/python3-omniorb-omg.install
+--- debian/python3-omniorb-omg.install	1970-01-01 09:00:00.000000000 +0900
++++ debian_mod/python3-omniorb-omg.install	2020-02-14 15:59:07.603476634 +0900
 @@ -0,0 +1,2 @@
 +usr/lib/python*/*-packages/*.py
 +usr/lib/python*/*-packages/CosNaming*
-diff -uprN debian422/python3-omniorb.install debian423/python3-omniorb.install
---- debian422/python3-omniorb.install	1970-01-01 01:00:00.000000000 +0100
-+++ debian423/python3-omniorb.install	2020-03-25 10:53:10.000000000 +0000
+diff -uprN debian/python3-omniorb.install debian_mod/python3-omniorb.install
+--- debian/python3-omniorb.install	1970-01-01 09:00:00.000000000 +0900
++++ debian_mod/python3-omniorb.install	2020-02-14 15:59:07.603476634 +0900
 @@ -0,0 +1,3 @@
 +usr/lib/python*/*-packages/omniORB.pth
 +usr/lib/python*/*-packages/_omni*-??m-*.so*
 +usr/lib/python*/*-packages/omniORB/
-diff -uprN debian422/rules debian423/rules
---- debian422/rules	2020-03-25 10:19:54.000000000 +0000
-+++ debian423/rules	2020-03-25 10:53:10.000000000 +0000
+diff -uprN debian/rules debian_mod/rules
+--- debian/rules	2020-02-14 15:59:28.748898635 +0900
++++ debian_mod/rules	2020-02-14 15:59:07.603476634 +0900
 @@ -23,7 +23,7 @@ ifeq (,$(findstring noopt,$(DEB_BUILD_OP
    CXX += -O2
  endif

--- a/ubuntu_1804/u1804-build.sh
+++ b/ubuntu_1804/u1804-build.sh
@@ -1,23 +1,23 @@
 #!/bin/bash
 #
-# Script to build omniORB 4.2.3, omniORBpy 4.2.3 and OpenRTM-aist-Python
+# Script to build omniORB 4.2.4, omniORBpy 4.2.4 and OpenRTM-aist-Python
 # in python3 environment of ubuntu 18.04.
 #
 # Patch the debian directory of omniORB omniORBpy 4.2.2.
-# Use this to create a deb package for omniORB and omniORBpy 4.2.3
+# Use this to create a deb package for omniORB and omniORBpy 4.2.4
 # in docker environment.
 # After that, create a deb package for Python3 of OpenRTM-aist-Python.
 #
 # Usage:
 #   $ sh u1804-build.sh
 #   $ ls artifacts
-#   libcos4-2_4.2.3-0.1_amd64.deb   libomnithread4-dev_4.2.3-0.1_amd64.deb
-#   omniidl_4.2.3-0.1_amd64.deb     omniorb_4.2.3-0.1_amd64.deb
+#   libcos4-2_4.2.4-0.1_amd64.deb   libomnithread4-dev_4.2.4-0.1_amd64.deb
+#   omniidl_4.2.4-0.1_amd64.deb     omniorb_4.2.4-0.1_amd64.deb
 #      :
-#   openrtm-aist-python3_1.2.1-1_amd64.deb
+#   openrtm-aist-python3_1.2.2-0_amd64.deb
 #
 TARGET=omniorb
-OMNI_VER=4.2.3
+OMNI_VER=4.2.4
 DIST_NAME=ubuntu1804
 
 OMNI_SHORT_VER=`echo ${OMNI_VER} | sed 's/\.//g'`


### PR DESCRIPTION
- Link to #5 
- omniORB 4.2.4, omniORBpy 4.2.4 各debパッケージを生成できるように整えた
- 修正後のスクリプトを実行し、下記debパッケージの生成を確認した

- Ubuntu 16.04
  ```
  libcos4-2-dbg_4.2.4-0.1_amd64.deb       libomnithread4-dev_4.2.4-0.1_amd64.deb  omniorb_4.2.4-0.1_amd64.deb
  libcos4-2_4.2.4-0.1_amd64.deb           libomnithread4_4.2.4-0.1_amd64.deb      openrtm-aist-python3-example_1.2.2-0_amd64.deb
  libcos4-dev_4.2.4-0.1_amd64.deb         omniidl-python3_4.2.4-0.1_all.deb       openrtm-aist-python3_1.2.2-0_amd64.deb
  libomniorb4-2-dbg_4.2.4-0.1_amd64.deb   omniidl_4.2.4-0.1_amd64.deb             python3-omniorb-dbg_4.2.4-0.1_amd64.deb
  libomniorb4-2_4.2.4-0.1_amd64.deb       omniorb-doc_4.2.4-0.1_all.deb           python3-omniorb-doc_4.2.4-0.1_all.deb
  libomniorb4-dev_4.2.4-0.1_amd64.deb     omniorb-idl_4.2.4-0.1_all.deb           python3-omniorb-omg_4.2.4-0.1_all.deb
  libomnithread4-dbg_4.2.4-0.1_amd64.deb  omniorb-nameserver_4.2.4-0.1_amd64.deb  python3-omniorb_4.2.4-0.1_amd64.deb
  ```

- Ubuntu 18.04
  ```
  libcos4-2-dbg_4.2.4-0.1_amd64.deb       libomnithread4_4.2.4-0.1_amd64.deb        openrtm-aist-python3-example_1.2.2-0_amd64.deb
  libcos4-2_4.2.4-0.1_amd64.deb           omniidl-python3_4.2.4-0.1_all.deb         openrtm-aist-python3_1.2.2-0_amd64.deb
  libcos4-dev_4.2.4-0.1_amd64.deb         omniidl_4.2.4-0.1_amd64.deb               python3-omniorb-dbg_4.2.4-0.1_amd64.deb
  libomniorb4-2-dbg_4.2.4-0.1_amd64.deb   omniorb-doc_4.2.4-0.1_all.deb             python3-omniorb-doc_4.2.4-0.1_all.deb
  libomniorb4-2_4.2.4-0.1_amd64.deb       omniorb-idl_4.2.4-0.1_all.deb             python3-omniorb-omg_4.2.4-0.1_all.deb
  libomniorb4-dev_4.2.4-0.1_amd64.deb     omniorb-nameserver_4.2.4-0.1_amd64.deb    python3-omniorb_4.2.4-0.1_amd64.deb
  libomnithread4-dbg_4.2.4-0.1_amd64.deb  omniorb_4.2.4-0.1_amd64.deb
  libomnithread4-dev_4.2.4-0.1_amd64.deb  openrtm-aist-python3-doc_1.2.2-0_all.deb
  ```

- Raspbian buster
  ```
  libcos4-2-dbg_4.2.4-0.1_armhf.deb       omniidl-dbgsym_4.2.4-0.1_armhf.deb             openrtm-aist-python3-doc_1.2.2-0_all.deb
  libcos4-2_4.2.4-0.1_armhf.deb           omniidl-python3_4.2.4-0.1_all.deb              openrtm-aist-python3-example_1.2.2-0_armhf.deb
  libcos4-dev_4.2.4-0.1_armhf.deb         omniidl_4.2.4-0.1_armhf.deb                    openrtm-aist-python3_1.2.2-0_armhf.deb
  libomniorb4-2-dbg_4.2.4-0.1_armhf.deb   omniorb-dbgsym_4.2.4-0.1_armhf.deb             python3-omniorb-dbg_4.2.4-0.1_armhf.deb
  libomniorb4-2_4.2.4-0.1_armhf.deb       omniorb-doc_4.2.4-0.1_all.deb                  python3-omniorb-doc_4.2.4-0.1_all.deb
  libomniorb4-dev_4.2.4-0.1_armhf.deb     omniorb-idl_4.2.4-0.1_all.deb                  python3-omniorb-omg_4.2.4-0.1_all.deb
  libomnithread4-dbg_4.2.4-0.1_armhf.deb  omniorb-nameserver-dbgsym_4.2.4-0.1_armhf.deb  python3-omniorb_4.2.4-0.1_armhf.deb
  libomnithread4-dev_4.2.4-0.1_armhf.deb  omniorb-nameserver_4.2.4-0.1_armhf.deb
  libomnithread4_4.2.4-0.1_armhf.deb      omniorb_4.2.4-0.1_armhf.deb
  ```


