### PR TITLE
Ubuntu16.04のomniidl-pythonがインストールされている環境へomniidl-python3をインストール可能とする修正

### DIFF
--- a/ubuntu_1604/omniORBpy-4.2.4_debian.patch
+++ b/ubuntu_1604/omniORBpy-4.2.4_debian.patch
@@ -81,7 +81,7 @@ diff -uprN debian/control debian_1604/control
  Description: CORBA OMG standard files for python-omniorb
   omniORB4 is a freely available Common Object Request Broker
   Architecture (CORBA) 2.6 compliant object request broker (ORB)
-@@ -78,10 +78,10 @@ Description: CORBA OMG standard files fo
+@@ -78,10 +78,12 @@ Description: CORBA OMG standard files fo
   python-pyorbit-omg since only one package can provide the default
   CORBA bindings.
  
@@ -91,6 +91,8 @@ diff -uprN debian/control debian_1604/control
 -Depends: omniidl, ${python:Depends}, ${misc:Depends}
 -Recommends: python-omniorb
 +Depends: omniidl, ${python3:Depends}, ${misc:Depends}
++Conflicts: omniidl-python
++Replaces: omniidl-python
 +Recommends: python3-omniorb
  Description: omniidl backend to compile Python stubs from IDL files
   omniORB4 is a freely available Common Object Request Broker


### PR DESCRIPTION
Link to #12 

OpenRTM-aist-Python 1.2.1 がインストールされている環境へ OpenRTM-aist-Python 1.2.2 をインストールし、作り直した omniidl-python3 がインストールされる動作を確認した。（テストリポジトリを使用）

- Ubuntu16.04 の OpenRTM-aist-Python 1.2.1 は、omniORB 4.1.6 の環境であった。現在、OpenRTM-aist をインストールしようとすると、omniORB 4.2.4 の omniorb-nameserver がインストールされてしまうので、バージョンを指定してインストールする必要がある。
```
$ sudo apt install omniorb-nameserver=4.1.6-2ubuntu1
$ dpkg -l | grep omni （抜粋）
　　：
ii  omniidl-python                             3.6-1
ii  omniorb-nameserver                         4.1.6-2ubuntu1
ii  python-omniorb                             3.6-1 
ii  python-omniorb-omg                         3.6-1

$ dpkg -l | grep openrtm
ii  openrtm-aist-python                        1.2.1-0
ii  openrtm-aist-python-example                1.2.1-0
```
- /etc/apt/sources.list の設定をテストリポジトリ（150.29.99.185）へ切り替える
- 今回、apt upsate でハッシュサムが適合しませんのエラーが出たので、設定ファイルを削除した
```
$ sudo apt install omniidl-python3 openrtm-aist-python3 openrtm-aist-python3-example
E: http://150.29.99.185/pub/Linux/ubuntu/dists/xenial/main/binary-amd64/omniidl-python3_4.2.4-0.1_all.deb の取得に失敗しました  ハッシュサムが適合しません
$ sudo rm -r /var/lib/apt/lists/*
$ sudo apt update
```
- この後、インストール処理が正常に行われることを確認した
```
$ sudo apt install omniidl-python3 openrtm-aist-python3 openrtm-aist-python3-example
$ dpkg -l | grep omni
       ：
ii  omniidl-python3                            4.2.4-0.1 
ii  omniorb-nameserver                         4.2.4-0.1
ii  python3-omniorb                            4.2.4-0.1
ii  python3-omniorb-omg                        4.2.4-0.1

$ dpkg -l | grep openrtm
ii  openrtm-aist-python                        1.2.1-0 
ii  openrtm-aist-python-example                1.2.1-0 
ii  openrtm-aist-python3                       1.2.2-0 
ii  openrtm-aist-python3-example               1.2.2-0
```

