### PR TITLE
omniORB4.2.4のビルドがUbuntu20.04 aarch64環境で通らない不具合修正

### DIFF
--- a/ubuntu_2004/omniORBpy-4.2.4_debian.patch
+++ b/ubuntu_2004/omniORBpy-4.2.4_debian.patch
@@ -106,7 +106,7 @@ diff -uprN debian422/python3-omniorb-dbg.install debian424/python3-omniorb-dbg.i
 --- debian422/python3-omniorb-dbg.install	1970-01-01 09:00:00.000000000 +0900
 +++ debian424/python3-omniorb-dbg.install	2020-05-26 09:52:56.548125458 +0900
 @@ -0,0 +1 @@
-+usr/lib/python*/*-packages/_omni*d-x*.so*
++usr/lib/python*/*-packages/_omni*d-*.so*
 diff -uprN debian422/python3-omniorb-omg.install debian424/python3-omniorb-omg.install
 --- debian422/python3-omniorb-omg.install	1970-01-01 09:00:00.000000000 +0900
 +++ debian424/python3-omniorb-omg.install	2020-05-26 09:50:24.884125458 +0900
@@ -118,7 +118,7 @@ diff -uprN debian422/python3-omniorb.install debian424/python3-omniorb.install
 +++ debian424/python3-omniorb.install	2020-05-26 09:50:24.884125458 +0900
 @@ -0,0 +1,3 @@
 +usr/lib/python*/*-packages/omniORB.pth
-+usr/lib/python*/*-packages/_omni*-??-x*.so*
++usr/lib/python*/*-packages/_omni*-??-*.so*
 +usr/lib/python*/*-packages/omniORB/
 diff -uprN debian422/rules debian424/rules
 --- debian422/rules	2020-05-26 09:48:41.920125458 +0900


### PR DESCRIPTION
close #14 

## Identify the Bug
Link to #14


## Description of the Change
- アーキテクチャ名の先頭文字として x を指定していたのをやめ、アスタリスク指定に含めるように変更した

## Verification 
- 変更したpatchファイルを使い、x86_64とaarch64環境でomniORB4.2.4のdebパッケージ生成を確認した
- [x] Did you succesed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
